### PR TITLE
MMX on RDKB

### DIFF
--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -68,7 +68,7 @@
 #
 ################################################################################
 
-override CC ?= gcc
+CC ?= gcc
 override CFLAGS += -c -fPIC -Wall -std=gnu99
 override LDFLAGS += -shared -fPIC -lmicroxml -ling-gen-utils
 
@@ -76,7 +76,7 @@ SOURCES=$(wildcard *.c)
 OBJECTS=$(SOURCES:.c=.o)
 TARGET_SO=libmmx-frontapi.so
 
-ifeq ($(PREFIX),)
+ifeq ($(strip $(PREFIX)),)
     PREFIX := /usr
 endif
 

--- a/src/c/Makefile
+++ b/src/c/Makefile
@@ -83,7 +83,7 @@ endif
 all: $(SOURCES) $(TARGET_SO)
 
 $(TARGET_SO): $(OBJECTS)
-	$(CC) $(OBJECTS) $(LDFLAGS) -o $@
+	$(CC) -Wl,-soname,$@ $(OBJECTS) $(LDFLAGS) -o $@
 
 install: 
 	install -d $(DESTDIR)$(PREFIX)/include

--- a/src/lua/Makefile
+++ b/src/lua/Makefile
@@ -68,16 +68,18 @@
 #
 ################################################################################
 
-ifeq ($(PREFIX),)
+ifeq ($(strip $(PREFIX)),)
     PREFIX := /usr
 endif
+
+LUAPATH ?= $(PREFIX)/lib/lua
 
 all clean:
 	echo "Nothing to do for $@"
 
 install:
-	install -d $(DESTDIR)$(PREFIX)/lib/lua/mmx
-	install -m 644 *.lua $(DESTDIR)$(PREFIX)/lib/lua/mmx
+	install -d $(DESTDIR)$(LUAPATH)/mmx
+	install -m 644 *.lua $(DESTDIR)$(LUAPATH)/mmx
 
 
 .PHONY: all clean install


### PR DESCRIPTION
    LUAPATH support

    Some distro install Lua modules in path containing Lua version,
    i.e. /usr/lib/lua/5.1

    Add support LUAPATH:
        Path for installation Lua modules
        Path is relative to $(DESTDIR)

Closes #1 